### PR TITLE
Develop

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -91,6 +91,7 @@ set(SCRAM_GUI_SRC
   diagramview.cpp
   diagram.cpp
   mainwindow.cpp
+  messagebox.cpp
   )
 ### End SCRAM GUI source list ### }}}
 add_library(scram-gui STATIC ${SCRAM_GUI_SRC} ${SCRAM_GUI_UI})

--- a/gui/eventdialog.cpp
+++ b/gui/eventdialog.cpp
@@ -441,7 +441,7 @@ void EventDialog::validate()
             GUI_ASSERT(it->top_events().empty() == false, );
             m_errorBar->showMessage(
                 //: Fault tree redefinition.
-                _("Fault tree '%1' is already defined with a top gate.")
+				_("Fault tree '%1' is already defined with a top gate. Please add new gates to the fault tree by adding a new element as new argument of a gate.")
                     .arg(faultTreeName));
             containerFaultTreeName->setStyleSheet(yellowBackground);
             return;

--- a/gui/eventdialog.cpp
+++ b/gui/eventdialog.cpp
@@ -431,8 +431,10 @@ void EventDialog::validate()
     }
 
     if (containerFaultTreeName->isEnabled()) {
-        if (containerFaultTreeName->hasAcceptableInput() == false)
+		if (containerFaultTreeName->hasAcceptableInput() == false) {
+			m_errorBar->showMessage(_("Please set fault tree name"));
             return;
+		}
         GUI_ASSERT(typeBox->currentIndex() == ext::one_bit_index(Gate), );
         QString faultTreeName = containerFaultTreeName->text();
         if (auto it = ext::find(m_model->fault_trees(),

--- a/gui/eventdialog.h
+++ b/gui/eventdialog.h
@@ -180,7 +180,7 @@ private:
     /// Connects the editing widgets with the dialog validation logic.
     void connectLineEdits(std::initializer_list<QLineEdit *> lineEdits);
 
-    void stealTopFocus(QLineEdit *lineEdit); ///< Intercepts the auto-default.
+	void stealTopFocus(QWidget* w); ///< Intercepts the auto-default.
 
     /// Sets up the formula argument completer.
     void setupArgCompleter();

--- a/gui/eventdialog.ui
+++ b/gui/eventdialog.ui
@@ -364,13 +364,6 @@
        </item>
        <item>
         <layout class="QGridLayout" name="gridLayout_2">
-         <item row="0" column="0">
-          <widget class="QLineEdit" name="addArgLine">
-           <property name="placeholderText">
-            <string>Add argument with its ID</string>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="0">
           <widget class="QListWidget" name="argsList">
            <property name="sizePolicy">
@@ -395,6 +388,13 @@
            <property name="icon">
             <iconset theme="list-add">
              <normaloff>.</normaloff>.</iconset>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QComboBox" name="cbArgsAdd">
+           <property name="placeholderText">
+            <string>Add argument with its ID</string>
            </property>
           </widget>
          </item>
@@ -478,8 +478,6 @@
   <tabstop>exponentialRate</tabstop>
   <tabstop>connectiveBox</tabstop>
   <tabstop>minNumberBox</tabstop>
-  <tabstop>addArgLine</tabstop>
-  <tabstop>addArgButton</tabstop>
   <tabstop>argsList</tabstop>
   <tabstop>removeArgButton</tabstop>
   <tabstop>containerModel</tabstop>

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -27,7 +27,6 @@
 #include <QCoreApplication>
 #include <QIcon>
 #include <QLibraryInfo>
-#include <QMessageBox>
 #include <QSettings>
 #include <QString>
 #include <QTranslator>
@@ -37,6 +36,7 @@
 
 #include "language.h"
 #include "mainwindow.h"
+#include "messagebox.h"
 
 #include "src/error.h"
 #include "src/version.h"
@@ -96,8 +96,7 @@ int parseArguments(int argc, char *argv[], po::variables_map *vm) noexcept
 void notifyError(const QString &title, const QString &text,
                  const QString &detail = {}) noexcept
 {
-    QMessageBox message(QMessageBox::Critical, title, text, QMessageBox::Ok);
-    message.setDetailedText(detail);
+	MessageBox message(QMessageBox::Critical, title, text, detail);
     message.exec();
 }
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1486,34 +1486,53 @@ void MainWindow::resetModelTree()
     });
 }
 
+bool MainWindow::activateTab(const QString& title) {
+	for (int i=0; i < ui->tabWidget->count(); i++) {
+		if (ui->tabWidget->tabText(i) == title) {
+			ui->tabWidget->setCurrentIndex(i);
+			return true;
+		}
+	}
+	return false;
+}
+
 void MainWindow::activateModelTree(const QModelIndex &index)
 {
     GUI_ASSERT(index.isValid(), );
     if (index.parent().isValid() == false) {
         switch (static_cast<ModelTree::Row>(index.row())) {
         case ModelTree::Row::Gates: {
+			const auto title = _("Gates");
+			if (activateTab(title))
+				return;
             auto *table = constructElementTable<model::GateContainerModel>(
                 m_guiModel.get(), this);
             //: The tab for the table of gates.
-            ui->tabWidget->addTab(table, _("Gates"));
+			ui->tabWidget->addTab(table, title);
             ui->tabWidget->setCurrentWidget(table);
             return;
         }
         case ModelTree::Row::BasicEvents: {
+			const auto title = _("Basic Events");
+			if (activateTab(title))
+				return;
             auto *table =
                 constructElementTable<model::BasicEventContainerModel>(
                     m_guiModel.get(), this);
             //: The tab for the table of basic events.
-            ui->tabWidget->addTab(table, _("Basic Events"));
+			ui->tabWidget->addTab(table, title);
             ui->tabWidget->setCurrentWidget(table);
             return;
         }
         case ModelTree::Row::HouseEvents: {
+			const auto title = _("House Events");
+			if (activateTab(title))
+				return;
             auto *table =
                 constructElementTable<model::HouseEventContainerModel>(
                     m_guiModel.get(), this);
             //: The tab for the table of house events.
-            ui->tabWidget->addTab(table, _("House Events"));
+			ui->tabWidget->addTab(table, title);
             ui->tabWidget->setCurrentWidget(table);
             return;
         }
@@ -1547,10 +1566,13 @@ void MainWindow::activateReportTree(const QModelIndex &index)
     QWidget *widget = nullptr;
     switch (static_cast<ReportTree::Row>(index.row())) {
     case ReportTree::Row::Products: {
+		const auto title = _("Products: %1").arg(name);
+		if (activateTab(title))
+			return;
         bool withProbability = result.probability_analysis != nullptr;
         auto *table = constructTableView<model::ProductTableModel>(
             this, result.fault_tree_analysis->products(), withProbability);
-        ui->tabWidget->addTab(table, _("Products: %1").arg(name));
+		ui->tabWidget->addTab(table, title);
         table->sortByColumn(withProbability ? 2 : 1, withProbability
                                                          ? Qt::DescendingOrder
                                                          : Qt::AscendingOrder);
@@ -1561,9 +1583,12 @@ void MainWindow::activateReportTree(const QModelIndex &index)
     case ReportTree::Row::Probability:
         break;
     case ReportTree::Row::Importance: {
+		const auto title = _("Importance: %1").arg(name);
+		if (activateTab(title))
+			return;
         widget = constructTableView<model::ImportanceTableModel>(
             this, &result.importance_analysis->importance());
-        ui->tabWidget->addTab(widget, _("Importance: %1").arg(name));
+		ui->tabWidget->addTab(widget, title);
         break;
     }
     default:
@@ -1581,6 +1606,11 @@ void MainWindow::activateFaultTreeDiagram(mef::FaultTree *faultTree)
 {
     GUI_ASSERT(faultTree, );
     GUI_ASSERT(faultTree->top_events().size() == 1, );
+
+	const auto title = _("Fault Tree: %1").arg(QString::fromStdString(faultTree->name()));
+	if (activateTab(title))
+		return;
+
     auto *topGate = faultTree->top_events().front();
     auto *view = new DiagramView(this);
     auto *scene = new diagram::DiagramScene(
@@ -1597,7 +1627,7 @@ void MainWindow::activateFaultTreeDiagram(mef::FaultTree *faultTree)
     ui->tabWidget->addTab(
         view,
         //: The tab for a fault tree diagram.
-        _("Fault Tree: %1").arg(QString::fromStdString(faultTree->name())));
+		title);
     ui->tabWidget->setCurrentWidget(view);
 
     connect(scene, &diagram::DiagramScene::activated, this,

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -248,6 +248,11 @@ private:
     /// Activates the model tree elements.
     void activateModelTree(const QModelIndex &index);
 
+	/// Activates the corresponding tab if it exists
+	/// return value: true if the tab with the title title is found
+	/// and set as current
+	bool activateTab(const QString& title);
+
     /// Activates the fault tree view.
     ///
     /// @param[in,out] faultTree  The valid fault tree to be shown in graphics.

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -239,9 +239,6 @@
    <addaction name="actionRun"/>
   </widget>
   <widget class="QDockWidget" name="modelDockWidget">
-   <property name="features">
-    <set>QDockWidget::AllDockWidgetFeatures</set>
-   </property>
    <property name="windowTitle">
     <string>Data</string>
    </property>
@@ -285,9 +282,6 @@
    </widget>
   </widget>
   <widget class="QDockWidget" name="reportDockWidget">
-   <property name="features">
-    <set>QDockWidget::AllDockWidgetFeatures</set>
-   </property>
    <property name="windowTitle">
     <string>Reports</string>
    </property>

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -212,6 +212,9 @@
    <property name="windowTitle">
     <string>Zoom Tool Bar</string>
    </property>
+   <property name="movable">
+    <bool>true</bool>
+   </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
    </attribute>

--- a/gui/messagebox.cpp
+++ b/gui/messagebox.cpp
@@ -1,0 +1,54 @@
+#include "messagebox.h"
+#include "ui_messagebox.h"
+#include "guiassert.h"
+
+#include <QStyle>
+
+MessageBox::MessageBox(QMessageBox::Icon icon, const QString& title, const QString &message, const QString& details, QWidget *parent) :
+	QDialog(parent),
+	ui(new Ui::MessageBox)
+{
+	ui->setupUi(this);
+	setWindowTitle(title);
+
+	QStyle *s = style();
+
+	// Inspired by QMessageBoxPrivate.h
+	QIcon tmpIcon;
+	switch (icon) {
+	case QMessageBox::Information:
+		tmpIcon = s->standardIcon(QStyle::SP_MessageBoxInformation, 0, this);
+		break;
+	case QMessageBox::Warning:
+		tmpIcon = s->standardIcon(QStyle::SP_MessageBoxWarning, 0, this);
+		break;
+	case QMessageBox::Critical:
+		tmpIcon = s->standardIcon(QStyle::SP_MessageBoxCritical, 0, this);
+		break;
+	case QMessageBox::Question:
+		tmpIcon = s->standardIcon(QStyle::SP_MessageBoxQuestion, 0, this);
+		break;
+	default:
+		// No Icon
+		break;
+	}
+	if (!tmpIcon.isNull())
+		ui->l_icon->setPixmap(tmpIcon.pixmap(30, 30));
+	ui->l_text->setText(message);
+	ui->te_details->setText(details);
+	ui->te_details->setVisible(false);
+
+	connect(ui->pb_show_details, &QPushButton::pressed, [=]() {
+		showDetails = !showDetails;
+		ui->te_details->setVisible(showDetails);
+	});
+
+	connect(ui->pb_ok, &QPushButton::pressed, [=] () {
+		accept();
+	});
+}
+
+MessageBox::~MessageBox()
+{
+	delete ui;
+}

--- a/gui/messagebox.cpp
+++ b/gui/messagebox.cpp
@@ -29,7 +29,7 @@ MessageBox::MessageBox(QMessageBox::Icon icon, const QString& title, const QStri
 		tmpIcon = s->standardIcon(QStyle::SP_MessageBoxQuestion, 0, this);
 		break;
 	default:
-		// No Icon
+		GUI_ASSERT(false && "No stadard icon!", );
 		break;
 	}
 	if (!tmpIcon.isNull())

--- a/gui/messagebox.h
+++ b/gui/messagebox.h
@@ -1,0 +1,24 @@
+#ifndef MESSAGEBOX_H
+#define MESSAGEBOX_H
+
+#include <QDialog>
+#include <QMessageBox>
+
+namespace Ui {
+class MessageBox;
+}
+
+class MessageBox : public QDialog
+{
+	Q_OBJECT
+
+public:
+	explicit MessageBox(QMessageBox::Icon icon, const QString &title, const QString& message, const QString &details, QWidget *parent = nullptr);
+	~MessageBox();
+
+private:
+	Ui::MessageBox *ui;
+	bool showDetails{false};
+};
+
+#endif // MESSAGEBOX_H

--- a/gui/messagebox.ui
+++ b/gui/messagebox.ui
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MessageBox</class>
+ <widget class="QDialog" name="MessageBox">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>484</width>
+    <height>292</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="l_icon">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="l_text">
+         <property name="text">
+          <string>Message</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QPushButton" name="pb_show_details">
+         <property name="text">
+          <string>Show Details...</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pb_ok">
+         <property name="text">
+          <string>OK</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QTextEdit" name="te_details"/>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
- do not create new tab if the tab already exists
- use custom message box which is able to resize its size
- show error message if not fault tree name is set
- make zoomtoolbar movable
- use combobox instead of a lineedit, so all elements are visible which can be use